### PR TITLE
No _id when updating by query. Bug Fix.

### DIFF
--- a/src/main/java/org/apache/kafka/connect/mongodb/DatabaseReader.java
+++ b/src/main/java/org/apache/kafka/connect/mongodb/DatabaseReader.java
@@ -102,7 +102,7 @@ public class DatabaseReader implements Runnable {
                 .sort(new Document("$natural", 1))
                 .skip(page * batchSize)
                 .limit(batchSize)
-                .projection(Projections.include("ts", "op", "ns", "o"))
+                .projection(Projections.include("ts", "op", "ns", "o", "o2"))
                 .cursorType(CursorType.TailableAwait);
         return documents;
     }

--- a/src/main/java/org/apache/kafka/connect/mongodb/converter/JsonStructConverter.java
+++ b/src/main/java/org/apache/kafka/connect/mongodb/converter/JsonStructConverter.java
@@ -24,6 +24,13 @@ public class JsonStructConverter implements StructConverter {
 		messageStruct.put("database", document.get("ns"));
 		
 		final Document modifiedDocument = (Document) document.get("o");
+		
+		if(modifiedDocument.get("_id") == null) {
+		    modifiedDocument.put("_id", ((Document) document.get("o2")).get("_id"));
+		}
+		
+		// modifiedDocument.computeIfAbsent("_id", k -> {return ((Document) document.get("o2")).get("_id");} );
+
 		messageStruct.put("object", modifiedDocument.toJson());
 
 		return messageStruct;


### PR DESCRIPTION
Link to the Issue
https://github.com/DataReply/kafka-connect-mongodb/issues/25

In case of update, "o" in mongo oplog doesn't contain _id. It is present in "o2".
Hence included "o2" in the projections from oplog document and added _id from "o2" to "o" when "o" doesn't contain _id.